### PR TITLE
added generic linux (.tar.gz) to pkgType config

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -28,7 +28,8 @@ let main = {
       'enum': [
         'Debian, Ubuntu',
         'RedHat',
-        'Mac OSX'
+        'Mac OSX',
+        'Generic Linux'
       ],
       'description': 'The type of package for download.'
     }
@@ -119,7 +120,9 @@ let main = {
     else if(atom.config.get('updater-notify.pkgType') === 'RedHat')
       pkgType = '.rpm';
     else if(atom.config.get('updater-notify.pkgType') === 'Mac OSX')
-      pkgType = '.nupkg';
+      pkgType = '.nupkg'
+    else if(atom.config.get('updater-notify.pkgType') === 'Generic Linux')
+      pkgType = '.tar.gz';
 
     up.checkUpdate().then(
       (info) => {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
       "enum": [
         "Debian, Ubuntu",
         "RedHat",
-        "Mac OSX"
+        "Mac OSX",
+        "Generic Linux"
       ],
       "description": "The type of package for download."
     }


### PR DESCRIPTION
Hi Rodrigo,
this is my first contribution to an Atom package. So maybe I'm doing all wrong :)
I like your package but needed a new package type to download the ".tar.gz" file.
Could you have a look and maybe release a new version?
What I stumbled upon is that the possible values for the config pkgType are not only in main.js but also in package.json. Can you explain me the reason or show me a good documentation that I can learn from?
Thanks a lot in advance!

Cheers,
Marc