### PR TITLE
when detecting Fedora, change the download link to the .rpm file

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -24,13 +24,15 @@ let main = {
     },
     pkgType: {
       'type': 'string',
-      'default': 'Debian, Ubuntu',
+      'default': 'DO_AUTODETECTION',
       'title': 'Package type',
       'enum': [
         'Debian, Ubuntu',
         'RedHat',
         'Mac OSX',
-        'Generic Linux'
+        'Generic Linux',
+        "Unknown",
+        "DO_AUTODETECTION"
       ],
       'description': 'The type of package for download.'
     }
@@ -69,7 +71,6 @@ let main = {
     });
 
     atom.config.onDidChange('updater-notify.pkgType', (values) => {
-      atom.notifications.addWarning("DEBUG: your OS is " + JSON.stringify(values));
       this.timer.stop();
       this.timer.start();
     });
@@ -202,8 +203,7 @@ let main = {
 
   identifyLinuxDistro() {
     // linux distros for the .rpm/.deb installation package https://github.com/retrohacker/getos/blob/master/os.json
-    var rpmDistros = ['Fedora','RHEL','RHAS','Red Hat Linux','Scientific Linux','ScientificSL','ScientificCERNSLC','ScientificFermiLTS',
-    'ScientificSLF','Centos'];
+    var rpmDistros = ['Fedora','RHEL','RHAS','Red Hat Linux','Centos'];
     var debDistros = ['Ubuntu Linux','SUSE Linux','Linux Mint','elementary OS','Debian','Raspbian','Knoppix'];
 
     // detect linux distribution

--- a/lib/main.js
+++ b/lib/main.js
@@ -201,9 +201,10 @@ let main = {
   },
 
   identifyLinuxDistro() {
-    // linux distros for the .rpm/.deb installation package
-    var rpmDistros = ['Fedora'];
-    var debDistros = ['Ubuntu Linux'];
+    // linux distros for the .rpm/.deb installation package https://github.com/retrohacker/getos/blob/master/os.json
+    var rpmDistros = ['Fedora','RHEL','RHAS','Red Hat Linux','Scientific Linux','ScientificSL','ScientificCERNSLC','ScientificFermiLTS',
+    'ScientificSLF','Centos'];
+    var debDistros = ['Ubuntu Linux','SUSE Linux','Linux Mint','elementary OS','Debian','Raspbian','Knoppix'];
 
     // detect linux distribution
     getos(function(e,os) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -5,6 +5,7 @@ import * as https from 'https';
 import {Updater} from './updater';
 import {Timer} from './timer';
 import {Notify} from './notify';
+import getos from 'getos';
 
 let main = {
 
@@ -52,20 +53,15 @@ let main = {
     // Events subscribed to in atom's system can be easily cleaned up with a CompositeDisposable
     this.subscriptions = new CompositeDisposable();
 
+    // detect OS for the first time after plugin installation
+    if ('DO_AUTODETECTION' === atom.config.get('updater-notify.pkgType')) {
+      this.identifyOS();
+    }
+
     // Register command that toggles this view
     this.subscriptions.add(atom.commands.add('atom-workspace', {
       'updater-notify:manualCheck': () => this.manualCheck()
     }));
-
-    // check if we have a Fedora linux distribution
-    if ('linux' === process.platform) {
-      const { exec } = require('child_process');
-      exec('cat /etc/*-release', function(err, stdout, stderr) {
-        if (stdout.includes('fedora')) {
-          atom.config.set('updater-notify.pkgType', 'RedHat');
-        }
-      });
-    }
 
     atom.config.onDidChange('updater-notify.acceptTestVersion', (values) => {
       this.timer.stop();
@@ -73,6 +69,7 @@ let main = {
     });
 
     atom.config.onDidChange('updater-notify.pkgType', (values) => {
+      atom.notifications.addWarning("DEBUG: your OS is " + JSON.stringify(values));
       this.timer.stop();
       this.timer.start();
     });
@@ -133,6 +130,8 @@ let main = {
       pkgType = '.nupkg'
     else if(atom.config.get('updater-notify.pkgType') === 'Generic Linux')
       pkgType = '.tar.gz';
+    else if(atom.config.get('updater-notify.pkgType') === 'DO_AUTODETECTION')
+      return; // dont display any information when performing an autodection
 
     up.checkUpdate().then(
       (info) => {
@@ -185,6 +184,44 @@ let main = {
         atom.notifications.addError(message);
       }
     );
+  },
+
+  identifyOS() {
+    switch(process.platform) {
+      case 'darwin':
+        atom.config.set('updater-notify.pkgType', 'Mac OSX');
+        break;
+      case 'linux':
+        this.identifyLinuxDistro();
+        break;
+      default:
+        atom.notifications.addWarning("updater-notify dont support your platform fully. Fallback to .zip installation package.");
+        atom.config.set('updater-notify.pkgType', 'Unknown');
+    }
+  },
+
+  identifyLinuxDistro() {
+    // linux distros for the .rpm/.deb installation package
+    var rpmDistros = ['Fedora'];
+    var debDistros = ['Ubuntu Linux'];
+
+    // detect linux distribution
+    getos(function(e,os) {
+      if (e) {
+        atom.notifications.addError("updater-notify could not detect your OS. Fallback to .zip installation package. Error: " + e);
+        atom.config.set('updater-notify.pkgType', 'Unknown');
+        return console.log(e)
+      }
+
+      // check if distro use .deb or .rpm
+      if (rpmDistros.includes(os.dist)) {
+        atom.config.set('updater-notify.pkgType', 'RedHat');
+      } else if (debDistros.includes(os.dist)) {
+        atom.config.set('updater-notify.pkgType', 'Debian, Ubuntu');
+      } else {
+        atom.config.set('updater-notify.pkgType', 'Generic Linux');
+      }
+    })
   }
 };
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -57,6 +57,16 @@ let main = {
       'updater-notify:manualCheck': () => this.manualCheck()
     }));
 
+    // check if we have a Fedora linux distribution
+    if ('linux' === process.platform) {
+      const { exec } = require('child_process');
+      exec('cat /etc/*-release', function(err, stdout, stderr) {
+        if (stdout.includes('fedora')) {
+          atom.config.set('updater-notify.pkgType', 'RedHat');
+        }
+      });
+    }
+
     atom.config.onDidChange('updater-notify.acceptTestVersion', (values) => {
       this.timer.stop();
       this.timer.start();

--- a/package.json
+++ b/package.json
@@ -34,13 +34,15 @@
     },
     "pkgType": {
       "type": "string",
-      "default": "Debian, Ubuntu",
+      "default": "DO_AUTODETECTION",
       "title": "Package type",
       "enum": [
         "Debian, Ubuntu",
         "RedHat",
         "Mac OSX",
-        "Generic Linux"
+        "Generic Linux",
+        "Unknown",
+        "DO_AUTODETECTION"
       ],
       "description": "The type of package for download."
     }
@@ -50,5 +52,7 @@
   "engines": {
     "atom": ">=1.0.0 <2.0.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "getos": "3.1.0"
+  }
 }


### PR DESCRIPTION
I encounter the following issue on my Fedora laptop. The plugin "updater-notify" only shows the download link for the .deb file (useless for Fedora user).

This new code will execute "cat /etc/*-release" on linux platforms and check if the output contains "fedora".

I have no experience in Atom plugins or nodejs. I hope the code is good enough :)